### PR TITLE
Standardlize object type

### DIFF
--- a/androidemu/java/classes/array.py
+++ b/androidemu/java/classes/array.py
@@ -1,0 +1,34 @@
+from androidemu.java.java_class_def import JavaClassDef
+from androidemu.java.java_field_def import JavaFieldDef
+from androidemu.java.java_method_def import java_method_def, JavaMethodDef
+
+class Array(metaclass=JavaClassDef, jvm_name='java/lang/reflect/Array'):
+
+    def __init__(self, jvm_type, pyitems):
+        self.__pyitems = pyitems
+        self.__jvm_type = jvm_type
+    #
+
+    def get_py_items(self):
+        return self.__pyitems
+    #
+
+    def __len__(self):
+        return len(self.__pyitems)
+    #
+
+    def __getitem__(self,index):
+        return self.__pyitems[index]
+    #
+
+    def __setitem__(self,index,value):
+        self.__pyitems[index] = value
+    #
+
+    @staticmethod
+    @java_method_def(name='set', signature='(Ljava/lang/Object;I)Ljava/lang/Object;', native=False)
+    def set(emu, obj, index):
+        raise NotImplementedError()
+    #
+    
+#

--- a/androidemu/java/classes/context.py
+++ b/androidemu/java/classes/context.py
@@ -1,9 +1,9 @@
 from androidemu.java.java_class_def import JavaClassDef
 from androidemu.java.java_field_def import JavaFieldDef
 from androidemu.java.java_method_def import java_method_def,JavaMethodDef
-from androidemu.java.classes.package_manager import PackageManager
+from androidemu.java.classes.package_manager import *
 from androidemu.java.classes.contentresolver import ContentResolver
-
+from androidemu.java.classes.string import String
 
 class Context(metaclass=JavaClassDef, jvm_name='android/content/Context',
                  jvm_fields=[
@@ -27,12 +27,19 @@ class Context(metaclass=JavaClassDef, jvm_name='android/content/Context',
     def getSystemService(self, emu, s1):
         pass
     #
+
+    @java_method_def(name='getApplicationInfo', signature='()Landroid/content/pm/ApplicationInfo;', native=False)
+    def getApplicationInfo(self, emu):
+        pass
+    #
 #
 
 class ContextImpl(Context, metaclass=JavaClassDef, jvm_name='android/app/ContextImpl', jvm_super=Context):
     def __init__(self):
         Context.__init__(self)
-        self.__pkg_mgr = PackageManager()
+        pyPkgName = "com.ss.android.ugc.aweme"
+        self.__pkgName = String(pyPkgName)
+        self.__pkg_mgr = PackageManager(pyPkgName)
         self.__resolver = ContentResolver()
     #
     
@@ -50,6 +57,18 @@ class ContextImpl(Context, metaclass=JavaClassDef, jvm_name='android/app/Context
     def getSystemService(self, emu, s1):
         print(s1)
         raise NotImplementedError()
+    #
+
+    @java_method_def(name='getApplicationInfo', signature='()Landroid/content/pm/ApplicationInfo;', native=False)
+    def getApplicationInfo(self, emu):
+        pkgMgr = self.__pkg_mgr
+        pkgInfo = pkgMgr.getPackageInfo(emu)
+        return pkgInfo.applicationInfo
+    #
+
+    @java_method_def(name='getPackageName', signature='()Ljava/lang/String;', native=False)
+    def getPackageName(self, emu):
+        return self.__pkgName
     #
 #
 
@@ -77,5 +96,15 @@ class ContextWrapper(Context, metaclass=JavaClassDef, jvm_name='android/content/
     @java_method_def(name='getSystemService', signature='(Ljava/lang/String;)Ljava/lang/Object;', native=False)
     def getSystemService(self, emu, s1):
         return self.__impl.getSystemService(emu, s1)
+    #
+
+    @java_method_def(name='getApplicationInfo', signature='()Landroid/content/pm/ApplicationInfo;', native=False)
+    def getApplicationInfo(self, emu):
+        return self.__impl.getApplicationInfo(emu)
+    #
+
+    @java_method_def(name='getPackageName', signature='()Ljava/lang/String;', native=False)
+    def getPackageName(self, emu):
+        return self.__impl.getPackageName(emu)
     #
 #

--- a/androidemu/java/classes/package_manager.py
+++ b/androidemu/java/classes/package_manager.py
@@ -13,12 +13,13 @@ jvm_fields=[
                      JavaFieldDef('flags', 'I', False),
                  ]):
     
-    def __init__(self):
-        self.sourceDir = String("/data/app/com.myxh.coolshopping/")
-        self.dataDir = String("/data/data/com.myxh.coolshopping/")
-        self.nativeLibraryDir = String("/data/data/com.myxh.coolshopping/lib/")
+    def __init__(self, pyPkgName):
+        self.sourceDir = String("/data/app/%s/"%pyPkgName)
+        self.dataDir = String("/data/data/%s"%pyPkgName)
+        self.nativeLibraryDir = String("/data/data/%s"%pyPkgName)
         self.flags = 0x30e8bf46
     #
+
 #
 
 class PackageInfo(metaclass=JavaClassDef, jvm_name='android/content/pm/PackageInfo', 
@@ -27,8 +28,8 @@ jvm_fields=[
                      JavaFieldDef('firstInstallTime', 'J', False),
                      JavaFieldDef('lastUpdateTime', 'J', False)                
                     ]):
-    def __init__(self):
-        self.applicationInfo = ApplicationInfo()
+    def __init__(self, pyPkgName):
+        self.applicationInfo = ApplicationInfo(pyPkgName)
         self.firstInstallTime = int(time.time())
         self.lastUpdateTime = self.firstInstallTime
     #
@@ -36,12 +37,12 @@ jvm_fields=[
 
 
 class PackageManager(metaclass=JavaClassDef, jvm_name='android/content/pm/PackageManager'):
-    def __init__(self):
-        self.__pkg_info = PackageInfo()
+    def __init__(self, pyPkgName):
+        self.__pkg_info = PackageInfo(pyPkgName)
     #
 
     @java_method_def(name='getPackageInfo', signature='(Ljava/lang/String;I)Landroid/content/pm/PackageInfo;', native=False)
-    def getPackageManager(self, emu):
+    def getPackageInfo(self, emu):
         return self.__pkg_info
     #
 #

--- a/androidemu/java/classes/string.py
+++ b/androidemu/java/classes/string.py
@@ -1,6 +1,7 @@
 from androidemu.java.java_class_def import JavaClassDef
 from androidemu.java.java_field_def import JavaFieldDef
 from androidemu.java.java_method_def import java_method_def, JavaMethodDef
+from androidemu.java.classes.array import Array
 
 class String(metaclass=JavaClassDef, jvm_name='java/lang/String'):
     
@@ -14,8 +15,10 @@ class String(metaclass=JavaClassDef, jvm_name='java/lang/String'):
 
     @java_method_def(name='getBytes', args_list=["jstring"], signature='(Ljava/lang/String;)[B', native=False)
     def getBytes(self, emu, charset):
-        print(charset)
-        raise NotImplementedError()
+        pycharset = charset.get_py_string()
+        barr = bytearray(self.__str, pycharset)
+        arr = Array("B", barr)
+        return arr
     #
 
     def __repr__(self):

--- a/androidemu/java/jni_env.py
+++ b/androidemu/java/jni_env.py
@@ -638,7 +638,7 @@ class JNIEnv:
         #
         pyobj = JNIEnv.jobject_to_pyobject(obj)
         clazz  = pyobj.__class__
-        return self.add_global_reference(jclass(clazz))
+        return self.add_local_reference(jclass(clazz))
     #
 
     @native_method

--- a/example_douyin.py
+++ b/example_douyin.py
@@ -16,6 +16,7 @@ from androidemu.java.java_method_def import java_method_def
 from androidemu.utils.chain_log import ChainLogger
 from androidemu.java.classes.string import String
 from androidemu.java.classes.list import List
+from androidemu.java.classes.array import Array
 
 
 class XGorgen(metaclass=JavaClassDef, jvm_name='com/ss/sys/ces/a'):
@@ -55,7 +56,7 @@ class java_lang_System(metaclass=JavaClassDef, jvm_name='java/lang/System'):
     @java_method_def(name='getProperty', args_list=["jstring"], signature='(Ljava/lang/String;)Ljava/lang/String;',
                      native=False)
     def getProperty(self, *args, **kwargs):
-        print(args[0].value)
+        print(args[0])
         return String("2.1.0")
 
 
@@ -189,7 +190,8 @@ try:
     x = XGorgen()
     data = 'acde74a94e6b493a3399fac83c7c08b35D58B21D9582AF77647FC9902E36AE70f9c001e9334e6e94916682224fbe4e5f00000000000000000000000000000000'
     data = bytearray(bytes.fromhex(data))
-    result = x.leviathan(emulator, 1562848170, data)
+    arr = Array("B", data)
+    result = x.leviathan(emulator, 1562848170, arr)
 
     print(''.join(['%02x' % b for b in result]))
     


### PR DESCRIPTION
重构，标准化传入传出参数，所有模拟Java的类传入参数是对象的话就是另外模拟的类，输出同理，比如，不再允许返回普通的python str，详细见example_douyin.py的String返回的处理